### PR TITLE
Add typed data methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,11 +78,17 @@ class SimpleKeyring extends EventEmitter {
 
   // personal_signTypedData, signs data along with the schema
   signTypedData (withAccount, typedData, opts = {}) {
+    return this.signTypedData_v3(withAccount, typedData, opts);
+  }
+
+  // personal_signTypedData, signs data along with the schema
+  signTypedData_v3 (withAccount, typedData, opts = {}) {
     const wallet = this._getWalletForAccount(withAccount, opts)
     const privKey = ethUtil.toBuffer(wallet.getPrivateKey())
     const sig = sigUtil.signTypedData(privKey, { data: typedData })
     return Promise.resolve(sig)
   }
+
 
   // returns an address specific to an app
   getAppKeyAddress (address, origin) {

--- a/index.js
+++ b/index.js
@@ -51,26 +51,23 @@ class SimpleKeyring extends EventEmitter {
 
   // tx is an instance of the ethereumjs-transaction class.
   signTransaction (address, tx, opts = {}) {
-    const wallet = this._getWalletForAccount(address, opts)
-    var privKey = wallet.getPrivateKey()
+    const privKey = this.getPrivateKeyFor(address, opts);
     tx.sign(privKey)
     return Promise.resolve(tx)
   }
 
   // For eth_sign, we need to sign arbitrary data:
-  signMessage (withAccount, data, opts = {}) {
-    const wallet = this._getWalletForAccount(withAccount, opts)
+  signMessage (address, data, opts = {}) {
     const message = ethUtil.stripHexPrefix(data)
-    var privKey = wallet.getPrivateKey()
+    const privKey = this.getPrivateKeyFor(address, opts);
     var msgSig = ethUtil.ecsign(new Buffer(message, 'hex'), privKey)
     var rawMsgSig = ethUtil.bufferToHex(sigUtil.concatSig(msgSig.v, msgSig.r, msgSig.s))
     return Promise.resolve(rawMsgSig)
   }
 
   // For personal_sign, we need to prefix the message:
-  signPersonalMessage (withAccount, msgHex, opts = {}) {
-    const wallet = this._getWalletForAccount(withAccount, opts)
-    const privKey = ethUtil.stripHexPrefix(wallet.getPrivateKey())
+  signPersonalMessage (address, msgHex, opts = {}) {
+    const privKey = this.getPrivateKeyFor(address, opts);
     const privKeyBuffer = new Buffer(privKey, 'hex')
     const sig = sigUtil.personalSign(privKeyBuffer, { data: msgHex })
     return Promise.resolve(sig)

--- a/index.js
+++ b/index.js
@@ -65,6 +65,16 @@ class SimpleKeyring extends EventEmitter {
     return Promise.resolve(rawMsgSig)
   }
 
+  // For eth_sign, we need to sign transactions:
+  newGethSignMessage (withAccount, msgHex, opts = {}) {
+    const privKey = this.getPrivateKeyFor(withAccount, opts);
+    const msgBuffer = ethUtil.toBuffer(msgHex)
+    const msgHash = ethUtil.hashPersonalMessage(msgBuffer)
+    const msgSig = ethUtil.ecsign(msgHash, privKey)
+    const rawMsgSig = ethUtil.bufferToHex(sigUtil.concatSig(msgSig.v, msgSig.r, msgSig.s))
+    return Promise.resolve(rawMsgSig)
+  }
+
   // For personal_sign, we need to prefix the message:
   signPersonalMessage (address, msgHex, opts = {}) {
     const privKey = this.getPrivateKeyFor(address, opts);

--- a/index.js
+++ b/index.js
@@ -83,21 +83,21 @@ class SimpleKeyring extends EventEmitter {
 
   // personal_signTypedData, signs data along with the schema
   signTypedData_v1 (withAccount, typedData, opts = {}) {
-    const privKey = this.getPrivateKeyFor(withAccount, opts); 
+    const privKey = this.getPrivateKeyFor(withAccount, opts);
     const sig = sigUtil.signTypedDataLegacy(privKey, { data: typedData })
     return Promise.resolve(sig)
   }
 
   // personal_signTypedData, signs data along with the schema
   signTypedData_v3 (withAccount, typedData, opts = {}) {
-    const privKey = this.getPrivateKeyFor(withAccount, opts); 
+    const privKey = this.getPrivateKeyFor(withAccount, opts);
     const sig = sigUtil.signTypedData(privKey, { data: typedData })
     return Promise.resolve(sig)
   }
 
   // personal_signTypedData, signs data along with the schema
   signTypedData_v4 (withAccount, typedData, opts = {}) {
-    const privKey = this.getPrivateKeyFor(withAccount, opts); 
+    const privKey = this.getPrivateKeyFor(withAccount, opts);
     const sig = sigUtil.signTypedData_v4(privKey, { data: typedData })
     return Promise.resolve(sig)
   }
@@ -108,7 +108,7 @@ class SimpleKeyring extends EventEmitter {
     }
     const wallet = this._getWalletForAccount(address, opts)
     const privKey = ethUtil.toBuffer(wallet.getPrivateKey())
-    return privKey; 
+    return privKey;
   }
 
   // returns an address specific to an app

--- a/index.js
+++ b/index.js
@@ -78,17 +78,38 @@ class SimpleKeyring extends EventEmitter {
 
   // personal_signTypedData, signs data along with the schema
   signTypedData (withAccount, typedData, opts = {}) {
-    return this.signTypedData_v3(withAccount, typedData, opts);
+    return this.signTypedData_v1(withAccount, typedData, opts);
+  }
+
+  // personal_signTypedData, signs data along with the schema
+  signTypedData_v1 (withAccount, typedData, opts = {}) {
+    const privKey = this.getPrivateKeyFor(withAccount, opts); 
+    const sig = sigUtil.signTypedDataLegacy(privKey, { data: typedData })
+    return Promise.resolve(sig)
   }
 
   // personal_signTypedData, signs data along with the schema
   signTypedData_v3 (withAccount, typedData, opts = {}) {
-    const wallet = this._getWalletForAccount(withAccount, opts)
-    const privKey = ethUtil.toBuffer(wallet.getPrivateKey())
+    const privKey = this.getPrivateKeyFor(withAccount, opts); 
     const sig = sigUtil.signTypedData(privKey, { data: typedData })
     return Promise.resolve(sig)
   }
 
+  // personal_signTypedData, signs data along with the schema
+  signTypedData_v4 (withAccount, typedData, opts = {}) {
+    const privKey = this.getPrivateKeyFor(withAccount, opts); 
+    const sig = sigUtil.signTypedData_v4(privKey, { data: typedData })
+    return Promise.resolve(sig)
+  }
+
+  getPrivateKeyFor (address, opts = {}) {
+    if (!address) {
+      throw new Error('Must specify address.');
+    }
+    const wallet = this._getWalletForAccount(address, opts)
+    const privKey = ethUtil.toBuffer(wallet.getPrivateKey())
+    return privKey; 
+  }
 
   // returns an address specific to an app
   getAppKeyAddress (address, origin) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-simple-keyring",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,11 @@
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-1.1.0.tgz",
       "integrity": "sha1-QtPXF0dPnqAiB/bRqh9CaRPut6w="
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
     "bindings": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
@@ -101,6 +106,15 @@
       "requires": {
         "bs58": "^3.1.0",
         "create-hash": "^1.1.0"
+      }
+    },
+    "buffer": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.2.tgz",
+      "integrity": "sha512-iy9koArjAFCzGnx3ZvNA6Z0clIbbFgbdWQ0mKD3hO0krOrZh8UgA6qMKcZvwLJxS+D6iVR76+5/pV56yMNYTag==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-xor": {
@@ -245,44 +259,39 @@
       "dev": true
     },
     "eth-sig-util": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.0.1.tgz",
-      "integrity": "sha512-lxHZOQspexk3DaGj4RBbWy4C/qNOWRnxpaJzNnYD3WEmC8shcJ4tHs7Xv878rzvILfJnSFSCCiKQhng1m80oBQ==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.4.3.tgz",
+      "integrity": "sha512-K6YDWGYGoRwKewzZ7jpWnh0nUM4wiArxvJkQWRDQ34CJhCX5/pTjVLy3mXsdOzPcKwHI3GasugoZo6oGp/UZnw==",
       "requires": {
-        "ethereumjs-util": "^5.1.1"
+        "buffer": "^5.2.1",
+        "elliptic": "^6.4.0",
+        "ethereumjs-abi": "0.6.5",
+        "ethereumjs-util": "^5.1.1",
+        "tweetnacl": "^1.0.0",
+        "tweetnacl-util": "^0.15.0"
       },
       "dependencies": {
         "ethereumjs-abi": {
-          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
-          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
+          "integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
           "requires": {
-            "bn.js": "^4.11.8",
-            "ethereumjs-util": "^6.0.0"
+            "bn.js": "^4.10.0",
+            "ethereumjs-util": "^4.3.0"
           },
           "dependencies": {
             "ethereumjs-util": {
-              "version": "6.1.0",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
-              "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+              "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
               "requires": {
-                "bn.js": "^4.11.0",
+                "bn.js": "^4.8.0",
                 "create-hash": "^1.1.2",
-                "ethjs-util": "0.1.6",
-                "keccak": "^1.0.2",
+                "keccakjs": "^0.2.0",
                 "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1",
                 "secp256k1": "^3.0.1"
               }
             }
-          }
-        },
-        "ethjs-util": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
-          "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
-          "requires": {
-            "is-hex-prefixed": "1.0.0",
-            "strip-hex-prefix": "1.0.0"
           }
         }
       }
@@ -509,6 +518,11 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -753,6 +767,16 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "tweetnacl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
+      "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
+    },
+    "tweetnacl-util": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.0.tgz",
+      "integrity": "sha1-RXbBzuXi1j0gf+5S8boCgZSAvHU="
     },
     "type-detect": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-simple-keyring",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "A simple standard interface for a series of Ethereum private keys.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/MetaMask/eth-simple-keyring#readme",
   "dependencies": {
-    "eth-sig-util": "^2.0.1",
+    "eth-sig-util": "^2.4.3",
     "ethereumjs-abi": "^0.6.5",
     "ethereumjs-util": "^5.1.1",
     "ethereumjs-wallet": "^0.6.0",

--- a/test/index.js
+++ b/test/index.js
@@ -197,24 +197,50 @@ describe('simple-keyring', () => {
 
   describe('#signTypedData', () => {
     const address = '0x29c76e6ad8f28bb1004902578fb108c507be341b'
-    const privKeyHex = '0x4af1bceebf7f3634ec3cff8a2c38e51178d5d4ce585c52d6043e5e2cc3418bb0'
+    const privKeyHex = '4af1bceebf7f3634ec3cff8a2c38e51178d5d4ce585c52d6043e5e2cc3418bb0'
+  
+    const privKey = Buffer.from(privKeyHex, 'hex')
+  
+    const typedData = [
+      {
+        type: 'string',
+        name: 'message',
+        value: 'Hi, Alice!'
+      }
+    ]
+    const msgParams = { data: typedData }
 
     it('returns the expected value', async () => {
-      const expectedSignature = '0xf2951a651df0a79b29a38215f9669b06499fa45d3b41c7acedd49c1050e8439f3283156a0797113c9c06c1df844495071aaa5721ea39198b46bf462f7417dfba1b'
-
-      const typedData = {
-        types: {
-          EIP712Domain: []
-        },
-        domain: {},
-        primaryType: 'EIP712Domain',
-        message: {}
-      }
-
       await keyring.deserialize([privKeyHex])
       const sig = await keyring.signTypedData(address, typedData)
-      assert.equal(sig, expectedSignature, 'signature matches')
-      const restored = sigUtil.recoverTypedSignature({ data: typedData, sig: sig })
+      const signedParams = Object.create(msgParams)
+      signedParams.sig = sig;
+      const restored = sigUtil.recoverTypedSignatureLegacy(signedParams)
+      assert.equal(restored, address, 'recovered address')
+    })
+  })
+
+  describe('#signTypedData_v1', () => {
+    const address = '0x29c76e6ad8f28bb1004902578fb108c507be341b'
+    const privKeyHex = '4af1bceebf7f3634ec3cff8a2c38e51178d5d4ce585c52d6043e5e2cc3418bb0'
+  
+    const privKey = Buffer.from(privKeyHex, 'hex')
+  
+    const typedData = [
+      {
+        type: 'string',
+        name: 'message',
+        value: 'Hi, Alice!'
+      }
+    ]
+    const msgParams = { data: typedData }
+
+    it('returns the expected value', async () => {
+      await keyring.deserialize([privKeyHex])
+      const sig = await keyring.signTypedData_v1(address, typedData)
+      const signedParams = Object.create(msgParams)
+      signedParams.sig = sig;
+      const restored = sigUtil.recoverTypedSignatureLegacy(signedParams)
       assert.equal(restored, address, 'recovered address')
     })
   })
@@ -224,8 +250,6 @@ describe('simple-keyring', () => {
     const privKeyHex = '0x4af1bceebf7f3634ec3cff8a2c38e51178d5d4ce585c52d6043e5e2cc3418bb0'
 
     it('returns the expected value', async () => {
-      const expectedSignature = '0xf2951a651df0a79b29a38215f9669b06499fa45d3b41c7acedd49c1050e8439f3283156a0797113c9c06c1df844495071aaa5721ea39198b46bf462f7417dfba1b'
-
       const typedData = {
         types: {
           EIP712Domain: []
@@ -237,31 +261,6 @@ describe('simple-keyring', () => {
 
       await keyring.deserialize([privKeyHex])
       const sig = await keyring.signTypedData_v3(address, typedData)
-      assert.equal(sig, expectedSignature, 'signature matches')
-      const restored = sigUtil.recoverTypedSignature({ data: typedData, sig: sig })
-      assert.equal(restored, address, 'recovered address')
-    })
-  })
-
-  describe('#signTypedData_v1', () => {
-    const address = '0x29c76e6ad8f28bb1004902578fb108c507be341b'
-    const privKeyHex = '0x4af1bceebf7f3634ec3cff8a2c38e51178d5d4ce585c52d6043e5e2cc3418bb0'
-
-    it('returns the expected value', async () => {
-      const expectedSignature = '0xf2951a651df0a79b29a38215f9669b06499fa45d3b41c7acedd49c1050e8439f3283156a0797113c9c06c1df844495071aaa5721ea39198b46bf462f7417dfba1b'
-
-      const typedData = {
-        types: {
-          EIP712Domain: []
-        },
-        domain: {},
-        primaryType: 'EIP712Domain',
-        message: {}
-      }
-
-      await keyring.deserialize([privKeyHex])
-      const sig = await keyring.signTypedData_v1(address, typedData)
-      assert.equal(sig, expectedSignature, 'signature matches')
       const restored = sigUtil.recoverTypedSignature({ data: typedData, sig: sig })
       assert.equal(restored, address, 'recovered address')
     })
@@ -272,8 +271,6 @@ describe('simple-keyring', () => {
     const privKeyHex = '0x4af1bceebf7f3634ec3cff8a2c38e51178d5d4ce585c52d6043e5e2cc3418bb0'
 
     it('returns the expected value', async () => {
-      const expectedSignature = '0xf2951a651df0a79b29a38215f9669b06499fa45d3b41c7acedd49c1050e8439f3283156a0797113c9c06c1df844495071aaa5721ea39198b46bf462f7417dfba1b'
-
       const typedData = {
         types: {
           EIP712Domain: []
@@ -285,7 +282,6 @@ describe('simple-keyring', () => {
 
       await keyring.deserialize([privKeyHex])
       const sig = await keyring.signTypedData_v4(address, typedData)
-      assert.equal(sig, expectedSignature, 'signature matches')
       const restored = sigUtil.recoverTypedSignature({ data: typedData, sig: sig })
       assert.equal(restored, address, 'recovered address')
     })
@@ -350,7 +346,7 @@ describe('simple-keyring', () => {
       assert.equal(expectedSig, sig, 'sign with app key generated private key')
     })
 
-    it('should signPersonalMessage with the expected key when passed a withAppKeyOrigin', async function () {
+    it('should signTypedData_v3 with the expected key when passed a withAppKeyOrigin', async function () {
       const address = testAccount.address
       const typedData = {
         types: {
@@ -366,7 +362,7 @@ describe('simple-keyring', () => {
       const expectedSig = sigUtil.signTypedData(privateKeyBuffer, { data: typedData })
 
       const keyring = new SimpleKeyring([testAccount.key])
-      const sig = await keyring.signTypedData(address, typedData, {
+      const sig = await keyring.signTypedData_v3(address, typedData, {
         withAppKeyOrigin: 'someapp.origin.io',
       })
 

--- a/test/index.js
+++ b/test/index.js
@@ -219,6 +219,30 @@ describe('simple-keyring', () => {
     })
   })
 
+  describe('#signTypedData_v3', () => {
+    const address = '0x29c76e6ad8f28bb1004902578fb108c507be341b'
+    const privKeyHex = '0x4af1bceebf7f3634ec3cff8a2c38e51178d5d4ce585c52d6043e5e2cc3418bb0'
+
+    it('returns the expected value', async () => {
+      const expectedSignature = '0xf2951a651df0a79b29a38215f9669b06499fa45d3b41c7acedd49c1050e8439f3283156a0797113c9c06c1df844495071aaa5721ea39198b46bf462f7417dfba1b'
+
+      const typedData = {
+        types: {
+          EIP712Domain: []
+        },
+        domain: {},
+        primaryType: 'EIP712Domain',
+        message: {}
+      }
+
+      await keyring.deserialize([privKeyHex])
+      const sig = await keyring.signTypedData_v3(address, typedData)
+      assert.equal(sig, expectedSignature, 'signature matches')
+      const restored = sigUtil.recoverTypedSignature({ data: typedData, sig: sig })
+      assert.equal(restored, address, 'recovered address')
+    })
+  })
+
   describe('getAppKeyAddress', function () {
     it('should return a public address custom to the provided app key origin', async function () {
       const address = testAccount.address

--- a/test/index.js
+++ b/test/index.js
@@ -327,7 +327,7 @@ describe('simple-keyring', () => {
       assert.equal(sig, expectedSig, 'verified signature')
       const signedData = Object.create(typedData)
       signedData.sig = sig
-      const restored = sigUtil.recoverTypedSignature(signedData)
+      const restored = sigUtil.recoverTypedSignature_v4(signedData)
       assert.equal(restored, address, 'recovered address')
     })
   })

--- a/test/index.js
+++ b/test/index.js
@@ -243,6 +243,54 @@ describe('simple-keyring', () => {
     })
   })
 
+  describe('#signTypedData_v1', () => {
+    const address = '0x29c76e6ad8f28bb1004902578fb108c507be341b'
+    const privKeyHex = '0x4af1bceebf7f3634ec3cff8a2c38e51178d5d4ce585c52d6043e5e2cc3418bb0'
+
+    it('returns the expected value', async () => {
+      const expectedSignature = '0xf2951a651df0a79b29a38215f9669b06499fa45d3b41c7acedd49c1050e8439f3283156a0797113c9c06c1df844495071aaa5721ea39198b46bf462f7417dfba1b'
+
+      const typedData = {
+        types: {
+          EIP712Domain: []
+        },
+        domain: {},
+        primaryType: 'EIP712Domain',
+        message: {}
+      }
+
+      await keyring.deserialize([privKeyHex])
+      const sig = await keyring.signTypedData_v1(address, typedData)
+      assert.equal(sig, expectedSignature, 'signature matches')
+      const restored = sigUtil.recoverTypedSignature({ data: typedData, sig: sig })
+      assert.equal(restored, address, 'recovered address')
+    })
+  })
+
+  describe('#signTypedData_v4', () => {
+    const address = '0x29c76e6ad8f28bb1004902578fb108c507be341b'
+    const privKeyHex = '0x4af1bceebf7f3634ec3cff8a2c38e51178d5d4ce585c52d6043e5e2cc3418bb0'
+
+    it('returns the expected value', async () => {
+      const expectedSignature = '0xf2951a651df0a79b29a38215f9669b06499fa45d3b41c7acedd49c1050e8439f3283156a0797113c9c06c1df844495071aaa5721ea39198b46bf462f7417dfba1b'
+
+      const typedData = {
+        types: {
+          EIP712Domain: []
+        },
+        domain: {},
+        primaryType: 'EIP712Domain',
+        message: {}
+      }
+
+      await keyring.deserialize([privKeyHex])
+      const sig = await keyring.signTypedData_v4(address, typedData)
+      assert.equal(sig, expectedSignature, 'signature matches')
+      const restored = sigUtil.recoverTypedSignature({ data: typedData, sig: sig })
+      assert.equal(restored, address, 'recovered address')
+    })
+  })
+
   describe('getAppKeyAddress', function () {
     it('should return a public address custom to the provided app key origin', async function () {
       const address = testAccount.address


### PR DESCRIPTION
Per https://github.com/MetaMask/metamask-extension/issues/7075

This adds all of the `signTypedData` methods currently supported by
MetaMask.

It has a breaking change:

`signTypedData` now explicitly redirects at a method named `signTypedData_v1`, which uses `eth-sig-util.signTypedDataLegacy` instead of `eth-sig-util.signTypedData`, which appears to be a breaking change, but actually I bumped the version of `eth-sig-util` to a version where the definition of `signTypedData` was changed. If I were reviewing that PR again I would never have allowed the name change, but that's what happened.

The good news is MetaMask isn't using that method anyways, so rather than tolerate another layer of poorly named variants, I cleaned up the names here to reflect the MetaMask API naming, and I don't believe it breaks any behavior that is in use today, I instead am fixing behavior I hope to use tomorrow.

Does not really validate the signatures, merely enforces that the
correct methods from `eth-sig-util` are being used, which has the more
detailed behavioral tests in its own repository.

Composed in such a way that now `eth-hd-keyring` could inherit from this
and instantly gain these new methods (I believe, would want to add tests
to be sure).