### PR TITLE
Pass version through typed sign method

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,8 +93,17 @@ class SimpleKeyring extends EventEmitter {
   }
 
   // personal_signTypedData, signs data along with the schema
-  signTypedData (withAccount, typedData, opts = {}) {
-    return this.signTypedData_v1(withAccount, typedData, opts);
+  signTypedData (withAccount, typedData, opts = { version: 'V1' }) {
+    switch (opts.version) {
+      case 'V1':
+        return this.signTypedData_v1(withAccount, typedData, opts);
+      case 'V3':
+        return this.signTypedData_v3(withAccount, typedData, opts);
+      case 'V4':
+        return this.signTypedData_v4(withAccount, typedData, opts);
+      default:
+        return this.signTypedData_v1(withAccount, typedData, opts);
+    }
   }
 
   // personal_signTypedData, signs data along with the schema

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,9 +109,9 @@
       }
     },
     "buffer": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.2.tgz",
-      "integrity": "sha512-iy9koArjAFCzGnx3ZvNA6Z0clIbbFgbdWQ0mKD3hO0krOrZh8UgA6qMKcZvwLJxS+D6iVR76+5/pV56yMNYTag==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+      "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
@@ -259,9 +259,9 @@
       "dev": true
     },
     "eth-sig-util": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.4.3.tgz",
-      "integrity": "sha512-K6YDWGYGoRwKewzZ7jpWnh0nUM4wiArxvJkQWRDQ34CJhCX5/pTjVLy3mXsdOzPcKwHI3GasugoZo6oGp/UZnw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.5.0.tgz",
+      "integrity": "sha512-ahApxr+e1cls/GwcFSGsgRLrMqG6D6cBnK9CRHhx97O/s9ow+URIxbPvov8jfE70ZnNBdHMircoSCpi1b4QHjA==",
       "requires": {
         "buffer": "^5.2.1",
         "elliptic": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-simple-keyring",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "A simple standard interface for a series of Ethereum private keys.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/MetaMask/eth-simple-keyring#readme",
   "dependencies": {
-    "eth-sig-util": "^2.4.3",
+    "eth-sig-util": "^2.5.0",
     "ethereumjs-abi": "^0.6.5",
     "ethereumjs-util": "^5.1.1",
     "ethereumjs-wallet": "^0.6.0",

--- a/test/index.js
+++ b/test/index.js
@@ -247,6 +247,16 @@ describe('simple-keyring', () => {
       const restored = sigUtil.recoverTypedSignatureLegacy(signedParams)
       assert.equal(restored, address, 'recovered address')
     })
+
+    it('works via version paramter', async () => {
+      await keyring.deserialize([privKeyHex])
+      const sig = await keyring.signTypedData(address, typedData)
+      const signedParams = Object.create(msgParams)
+      signedParams.sig = sig;
+      assert.equal(sig, expectedSig, 'produced correct signature.')
+      const restored = sigUtil.recoverTypedSignatureLegacy(signedParams)
+      assert.equal(restored, address, 'recovered address')
+    })
   })
 
   describe('#signTypedData_v3', () => {
@@ -265,6 +275,22 @@ describe('simple-keyring', () => {
 
       await keyring.deserialize([privKeyHex])
       const sig = await keyring.signTypedData_v3(address, typedData)
+      const restored = sigUtil.recoverTypedSignature({ data: typedData, sig: sig })
+      assert.equal(restored, address, 'recovered address')
+    })
+
+    it('works via the version parameter', async () => {
+      const typedData = {
+        types: {
+          EIP712Domain: []
+        },
+        domain: {},
+        primaryType: 'EIP712Domain',
+        message: {}
+      }
+
+      await keyring.deserialize([privKeyHex])
+      const sig = await keyring.signTypedData(address, typedData, { version: 'V3' })
       const restored = sigUtil.recoverTypedSignature({ data: typedData, sig: sig })
       assert.equal(restored, address, 'recovered address')
     })
@@ -309,7 +335,7 @@ describe('simple-keyring', () => {
       assert.equal(restored, address, 'recovered address')
     })
   })
-  
+
   describe('#decryptMessage', () => {
     it('returns the expected value', async () => {
       const address = '0xbe93f9bacbcffc8ee6663f2647917ed7a20a57bb'
@@ -317,7 +343,7 @@ describe('simple-keyring', () => {
       const privKeyHex = ethUtil.bufferToHex(privateKey)
       const message = 'Hello world!'
 	  const encryptedMessage = sigUtil.encrypt(sigUtil.getEncryptionPublicKey(privateKey), {'data': message}, 'x25519-xsalsa20-poly1305')
-	  
+
 	  await keyring.deserialize([privKeyHex])
       const decryptedMessage = await keyring.decryptMessage(address, encryptedMessage)
       assert.equal(message, decryptedMessage, 'signature matches')


### PR DESCRIPTION
After this is merged, still need to:

- [ ] Bump `eth-hd-keyring` to inherit from this.
- [ ] Update `eth-keyring-controller` to pass through an equivalent parameter.
- [ ] Edit the metamask controller to use this method instead of signing within its body.