### PR TITLE
Ensure app key origin is a non-empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,6 +138,12 @@ class SimpleKeyring extends EventEmitter {
 
   // returns an address specific to an app
   getAppKeyAddress (address, origin) {
+    if (
+      !origin ||
+      typeof origin !== 'string'
+    ) {
+      throw new Error(`'origin' must be a non-empty string`)
+    }
     return new Promise((resolve, reject) => {
       try {
         const wallet = this._getWalletForAccount(address, {

--- a/test/index.js
+++ b/test/index.js
@@ -413,6 +413,32 @@ describe('simple-keyring', () => {
 
       assert.equal(appKeyAddress1, appKeyAddress2)
     })
+
+    it('should throw error if the provided origin is not a string', async function () {
+      const address = testAccount.address
+      const keyring = new SimpleKeyring([testAccount.key])
+
+      try {
+        await keyring.getAppKeyAddress(address, [])
+      } catch (error) {
+        assert(error instanceof Error, 'Value thrown is not an error')
+        return
+      }
+      assert.fail('Should have thrown error')
+    })
+
+    it('should throw error if the provided origin is an empty string', async function () {
+      const address = testAccount.address
+      const keyring = new SimpleKeyring([testAccount.key])
+
+      try {
+        await keyring.getAppKeyAddress(address, '')
+      } catch (error) {
+        assert(error instanceof Error, 'Value thrown is not an error')
+        return
+      }
+      assert.fail('Should have thrown error')
+    })
   })
 
   describe('signing methods withAppKeyOrigin option', function () {


### PR DESCRIPTION
This ensures that only strings can be submitted as the origin, and that they are non-empty. We could additionally check that the origin provided is valid, but I'm not sure what format to expect for those yet.