### PR TITLE
Replace `withAppKeyOrigin` option with `getAppKey`

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,13 +96,13 @@ class SimpleKeyring extends EventEmitter {
   signTypedData (withAccount, typedData, opts = { version: 'V1' }) {
     switch (opts.version) {
       case 'V1':
-        return this.signTypedData_v1(withAccount, typedData, opts);
+        return this.signTypedData_v1(withAccount, typedData);
       case 'V3':
-        return this.signTypedData_v3(withAccount, typedData, opts);
+        return this.signTypedData_v3(withAccount, typedData);
       case 'V4':
-        return this.signTypedData_v4(withAccount, typedData, opts);
+        return this.signTypedData_v4(withAccount, typedData);
       default:
-        return this.signTypedData_v1(withAccount, typedData, opts);
+        return this.signTypedData_v1(withAccount, typedData);
     }
   }
 
@@ -136,7 +136,7 @@ class SimpleKeyring extends EventEmitter {
     return privKey;
   }
 
-  getAppKeyring (address, origin) {
+  async getAppKey (address, origin) {
     if (
       !origin ||
       typeof origin !== 'string'
@@ -149,13 +149,14 @@ class SimpleKeyring extends EventEmitter {
     const appKeyOriginBuffer = Buffer.from(origin, 'utf8')
     const appKeyBuffer = Buffer.concat([privKey, appKeyOriginBuffer])
     const appKeyPrivKey = ethUtil.keccak(appKeyBuffer, 256)
-    return new SimpleKeyring([appKeyPrivKey.toString('hex')])
+    return appKeyPrivKey
   }
 
   async getAppKeyAddress (address, origin) {
-    const keyring = this.getAppKeyring(address, origin)
-    const accounts = await keyring.getAccounts()
-    return accounts[0]
+    const key = await this.getAppKey(address, origin)
+    const wallet = Wallet.fromPrivateKey(key)
+    const appKeyAddress = wallet.getAddress()
+    return ethUtil.bufferToHex(appKeyAddress)
   }
 
   // exportAccount should return a hex-encoded private key:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-simple-keyring",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-simple-keyring",
-  "version": "3.4.0",
+  "version": "4.0.0",
   "description": "A simple standard interface for a series of Ethereum private keys.",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -415,61 +415,53 @@ describe('simple-keyring', () => {
     })
   })
 
-  describe('getAppKeyring', function () {
-    it('should return a SimpleKeyring custom to the provided app origin', async function () {
-      const address = testAccount.address
-      const keyring = new SimpleKeyring([testAccount.key])
+  describe('getAppKey', function () {
+    it('should return a private key custom to the provided app origin', async function () {
+      const { address, key } = testAccount
+      const keyring = new SimpleKeyring([key])
 
-      const appKeyring = await keyring.getAppKeyring(address, 'someapp.origin.io')
+      const appKey = await keyring.getAppKey(address, 'someapp.origin.io')
 
-      assert(appKeyring instanceof SimpleKeyring)
-
-      const appKeyAddress = (await appKeyring.getAccounts())[0]
-
-      assert.notEqual(address, appKeyAddress)
-      assert(ethUtil.isValidAddress(appKeyAddress))
+      assert.notEqual(key, appKey)
+      assert(ethUtil.isValidPrivate(appKey))
     })
 
     it('should return different keyrings when provided different app origins', async function () {
-      const address = testAccount.address
-      const keyring = new SimpleKeyring([testAccount.key])
+      const { address, key } = testAccount
+      const keyring = new SimpleKeyring([key])
 
-      const appKeyring1 = await keyring.getAppKeyring(address, 'someapp.origin.io')
-      const appKeyAddress1 = (await appKeyring1.getAccounts())[0]
+      const appKey1 = await keyring.getAppKey(address, 'someapp.origin.io')
 
-      assert(ethUtil.isValidAddress(appKeyAddress1))
+      assert(ethUtil.isValidPrivate(appKey1))
 
-      const appKeyring2 = await keyring.getAppKeyring(address, 'anotherapp.origin.io')
-      const appKeyAddress2 = (await appKeyring2.getAccounts())[0]
+      const appKey2 = await keyring.getAppKey(address, 'anotherapp.origin.io')
 
-      assert(ethUtil.isValidAddress(appKeyAddress2))
+      assert(ethUtil.isValidPrivate(appKey2))
 
-      assert.notEqual(appKeyAddress1, appKeyAddress2)
+      assert.notEqual(appKey1.toString('hex'), appKey2.toString('hex'))
     })
 
     it('should return the same keyring when called multiple times with the same params', async function () {
-      const address = testAccount.address
-      const keyring = new SimpleKeyring([testAccount.key])
+      const { address, key } = testAccount
+      const keyring = new SimpleKeyring([key])
 
-      const appKeyring1 = await keyring.getAppKeyring(address, 'someapp.origin.io')
-      const appKeyAddress1 = (await appKeyring1.getAccounts())[0]
+      const appKey1 = await keyring.getAppKey(address, 'someapp.origin.io')
 
-      assert(ethUtil.isValidAddress(appKeyAddress1))
+      assert(ethUtil.isValidPrivate(appKey1))
 
-      const appKeyring2 = await keyring.getAppKeyring(address, 'someapp.origin.io')
-      const appKeyAddress2 = (await appKeyring2.getAccounts())[0]
+      const appKey2 = await keyring.getAppKey(address, 'someapp.origin.io')
 
-      assert(ethUtil.isValidAddress(appKeyAddress2))
+      assert(ethUtil.isValidPrivate(appKey2))
 
-      assert.equal(appKeyAddress1, appKeyAddress2)
+      assert.equal(appKey1.toString('hex'), appKey2.toString('hex'))
     })
 
     it('should throw error if the provided origin is not a string', async function () {
-      const address = testAccount.address
-      const keyring = new SimpleKeyring([testAccount.key])
+      const { address, key } = testAccount
+      const keyring = new SimpleKeyring([key])
 
       try {
-        await keyring.getAppKeyring(address, [])
+        await keyring.getAppKey(address, [])
       } catch (error) {
         assert(error instanceof Error, 'Value thrown is not an error')
         return
@@ -478,11 +470,11 @@ describe('simple-keyring', () => {
     })
 
     it('should throw error if the provided origin is an empty string', async function () {
-      const address = testAccount.address
-      const keyring = new SimpleKeyring([testAccount.key])
+      const { address, key } = testAccount
+      const keyring = new SimpleKeyring([key])
 
       try {
-        await keyring.getAppKeyring(address, '')
+        await keyring.getAppKey(address, '')
       } catch (error) {
         assert(error instanceof Error, 'Value thrown is not an error')
         return


### PR DESCRIPTION
The new `getAppKeyring` method will return a new SimpleKeyring created with an app key derived from the provided origin. This serves as an alternative to optionally augmenting each wallet method with a set of options that may contain a `withAppKeyOrigin` value, which would be used to generate a new wallet on-demand.

Moving app key generation to a single place makes it easier to limit access to sensitive information, such as the primary private keys. It also allows the consumer to use app keys more efficiently by using the same wallet for successive operations, rather than generating a new private key each time with `keccak`.

Update: A private key is now returned instead of a keyring. This private app key is less restrictive, as it can be used to construct a SimpleKeyring or any other keyring/wallet the consumer might prefer to use.