### PR TITLE
Remove redundant hex encoding for messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ class SimpleKeyring extends EventEmitter {
     const message = ethUtil.stripHexPrefix(data)
     const privKey = this.getPrivateKeyFor(address, opts)
     const msgSig = ethUtil.ecsign(Buffer.from(message, 'hex'), privKey)
-    const rawMsgSig = ethUtil.bufferToHex(sigUtil.concatSig(msgSig.v, msgSig.r, msgSig.s))
+    const rawMsgSig = sigUtil.concatSig(msgSig.v, msgSig.r, msgSig.s)
     return Promise.resolve(rawMsgSig)
   }
 
@@ -70,7 +70,7 @@ class SimpleKeyring extends EventEmitter {
     const msgBuffer = ethUtil.toBuffer(msgHex)
     const msgHash = ethUtil.hashPersonalMessage(msgBuffer)
     const msgSig = ethUtil.ecsign(msgHash, privKey)
-    const rawMsgSig = ethUtil.bufferToHex(sigUtil.concatSig(msgSig.v, msgSig.r, msgSig.s))
+    const rawMsgSig = sigUtil.concatSig(msgSig.v, msgSig.r, msgSig.s)
     return Promise.resolve(rawMsgSig)
   }
 


### PR DESCRIPTION
Closes #5

This PR fixes a longstanding issue with `#signMessage` and `#newGethSignMessage` where the result of [`sigUtil.concatSig`][1] was being re-encoded as hex via `ethUtil.bufferToHex`.

The return value of `concatSig` 1) isn't a Buffer and 2) is already a hex-encoded string.

  [1]:https://github.com/MetaMask/eth-sig-util/blob/c03817eafd2a6b9a768b84089d227c3bee750303/index.ts#L270-L278
  [1]:https://github.com/ethereumjs/ethereumjs-util/blob/7e3be1d97b4e11fbc4924836b8c444e644f643ac/index.js#L195-L203