### PR TITLE
Remove Greenkeeper badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Simple Keyring [![CircleCI](https://circleci.com/gh/MetaMask/eth-simple-keyring.svg?style=svg)](https://circleci.com/gh/MetaMask/eth-simple-keyring)
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/MetaMask/eth-simple-keyring.svg)](https://greenkeeper.io/)
-
 A simple JS class wrapped around [ethereumjs-wallet](https://github.com/ethereumjs/ethereumjs-wallet) designed to expose an interface common to many different signing strategies to be used in a `KeyringController`; such as the one used in [MetaMask](https://metamask.io/)
 
 ## The Keyring Class Protocol


### PR DESCRIPTION
This PR removes the Greenkeeper badge from the README file.