### PR TITLE
Use @metamask/eslint-config@3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "events": "^1.1.1"
   },
   "devDependencies": {
-    "@metamask/eslint-config": "^2.1.1",
+    "@metamask/eslint-config": "^3.2.0",
     "chai": "^4.1.2",
     "eslint": "^7.2.0",
     "eslint-plugin-import": "^2.21.2",

--- a/test/index.js
+++ b/test/index.js
@@ -381,7 +381,6 @@ describe('simple-keyring', () => {
     })
   })
 
-
   describe('getAppKeyAddress', function () {
     it('should return a public address custom to the provided app key origin', async function () {
       const { address } = testAccount

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@metamask/eslint-config@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-2.1.1.tgz#df38ff2199783ac2e7726b17d140328d1cb595f9"
-  integrity sha512-DBixWzP6B5q00OPYXhRFg6GlR5ZxXWDOFeSa31I31GjZCEVY4NUwjSAT10UEaR7RncUI0WONXIC/P3P43UZx3w==
+"@metamask/eslint-config@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-3.2.0.tgz#66b9b2bea1616821506501e76de4ac991f34914f"
+  integrity sha512-WKfB81fD5NZBFbj/UqMyfNss/b25XrukVC3j2mcaIEF0uzSKzh1b/yy7aXxcfXshWemHz28MOwZT9Bin5KV37w==
 
 "@types/color-name@^1.1.1":
   version "1.1.1"


### PR DESCRIPTION
This PR updates the shared ESLint config to the latest published version, v3.2.0.