### PR TITLE
Remove unnecessary no-plusplus rule config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,6 @@ module.exports = {
     },
   }],
   rules: {
-    'no-plusplus': ['error', { 'allowForLoopAfterthoughts': true }],
     'camelcase': ['error', {
       'allow': [
         'signTypedData_v1',


### PR DESCRIPTION
This made its way into the shared config as of [v2.2.0](https://github.com/MetaMask/eslint-config/blob/master/CHANGELOG.md#220---2020-07-14).