### PR TITLE
support newer versons of ethereumjs/tx with immutability

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,8 +51,9 @@ class SimpleKeyring extends EventEmitter {
   // tx is an instance of the ethereumjs-transaction class.
   signTransaction (address, tx, opts = {}) {
     const privKey = this.getPrivateKeyFor(address, opts)
-    tx.sign(privKey)
-    return Promise.resolve(tx)
+    const signedTx = tx.sign(privKey)
+    // Newer versions of Ethereumjs-tx are immutable and return a new tx object
+    return Promise.resolve(signedTx === undefined ? tx : signedTx)
   }
 
   // For eth_sign, we need to sign arbitrary data:

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "events": "^1.1.1"
   },
   "devDependencies": {
+    "@ethereumjs/tx": "^3.1.1",
     "@metamask/eslint-config": "^3.2.0",
     "chai": "^4.1.2",
     "eslint": "^7.2.0",

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ const assert = require('assert')
 const ethUtil = require('ethereumjs-util')
 const sigUtil = require('eth-sig-util')
 const { Transaction: EthereumTx } = require('ethereumjs-tx')
+const { TransactionFactory } = require('@ethereumjs/tx')
 const { expect } = require('chai')
 const SimpleKeyring = require('..')
 
@@ -78,6 +79,23 @@ describe('simple-keyring', () => {
         value: '0x1000',
       }
       const tx = new EthereumTx(txParams)
+
+      const signed = await keyring.signTransaction(address, tx)
+      assert.ok(signed.raw, 'has a raw signature')
+    })
+
+    it('returns a signed tx object when using newer versions of ethereumjs/tx', async () => {
+      await keyring.deserialize([privateKey])
+
+      const txParams = {
+        from: address,
+        nonce: '0x00',
+        gasPrice: '0x09184e72a000',
+        gasLimit: '0x2710',
+        to: address,
+        value: '0x1000',
+      }
+      const tx = TransactionFactory.fromTxData(txParams)
 
       const signed = await keyring.signTransaction(address, tx)
       assert.ok(signed.raw, 'has a raw signature')

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,22 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@ethereumjs/common@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-2.2.0.tgz#850a3e3e594ee707ad8d44a11e8152fb62450535"
+  integrity sha512-PyQiTG00MJtBRkJmv46ChZL8u2XWxNBeAthznAUIUiefxPAXjbkuiCZOuncgJS34/XkMbNc9zMt/PlgKRBElig==
+  dependencies:
+    crc-32 "^1.2.0"
+    ethereumjs-util "^7.0.9"
+
+"@ethereumjs/tx@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.1.1.tgz#e8d6943baa955b2d197d2f6f7864939991b8feb3"
+  integrity sha512-IuN9EUT6sCZrldVbgQA+XuuxouUvMdoW34qZvlzFtCgjlvKJ848iK/lDTJVVPNb3WndlEu3d2a7Mu474ggdT/g==
+  dependencies:
+    "@ethereumjs/common" "^2.2.0"
+    ethereumjs-util "^7.0.9"
+
 "@metamask/eslint-config@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-3.2.0.tgz#66b9b2bea1616821506501e76de4ac991f34914f"
@@ -46,9 +62,9 @@
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
 "@types/node@*":
-  version "14.14.36"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.36.tgz#5637905dbb15c30a33a3c65b9ef7c20e3c85ebad"
-  integrity sha512-kjivUwDJfIjngzbhooRnOLhGYz6oRFi+L+EpMjxroDYXwDw9lHrJJ43E+dJ6KAd3V3WxWAJ/qZE9XKYHhjPOFQ==
+  version "14.14.35"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.35.tgz#42c953a4e2b18ab931f72477e7012172f4ffa313"
+  integrity sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
 
 "@types/pbkdf2@^3.0.0":
   version "3.1.0"
@@ -479,6 +495,14 @@ contains-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
   integrity sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
+
+crc-32@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.0.tgz#cb2db6e29b88508e32d9dd0ec1693e7b41a18208"
+  integrity sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==
+  dependencies:
+    exit-on-epipe "~1.0.1"
+    printj "~1.1.0"
 
 create-hash@^1.1.0, create-hash@^1.1.1, create-hash@^1.1.2, create-hash@^1.2.0:
   version "1.2.0"
@@ -957,6 +981,11 @@ evp_bytestokey@^1.0.3:
   dependencies:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
+
+exit-on-epipe@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692"
+  integrity sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==
 
 external-editor@^3.0.3:
   version "3.1.0"
@@ -1825,6 +1854,11 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+printj@~1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
+  integrity sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==
 
 progress@^2.0.0:
   version "2.0.3"


### PR DESCRIPTION
The current implementation of the sign method relies on mutation, which was the case pre version 3.0.0 of ethereumjs/tx. In earlier versions of the library, the passed tx object was modified. In version 3.0.0 immutability and Object.freeze were implemented, and the newly signed tx is returned as a brand new instance of the Transaction.

The change presented here should allow both versions (mutable and immutable) to function, preferring the immutable version.