### PR TITLE
Remove redundant `newGethSignMessage` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,16 +65,6 @@ class SimpleKeyring extends EventEmitter {
     return Promise.resolve(rawMsgSig)
   }
 
-  // For eth_sign, we need to sign transactions:
-  newGethSignMessage (withAccount, msgHex, opts = {}) {
-    const privKey = this.getPrivateKeyFor(withAccount, opts)
-    const msgBuffer = ethUtil.toBuffer(msgHex)
-    const msgHash = ethUtil.hashPersonalMessage(msgBuffer)
-    const msgSig = ethUtil.ecsign(msgHash, privKey)
-    const rawMsgSig = sigUtil.concatSig(msgSig.v, msgSig.r, msgSig.s)
-    return Promise.resolve(rawMsgSig)
-  }
-
   // For personal_sign, we need to prefix the message:
   signPersonalMessage (address, msgHex, opts = {}) {
     const privKey = this.getPrivateKeyFor(address, opts)


### PR DESCRIPTION
The `newGethSignMessage` method has been removed. This method was identical to `signPersonalMessage`, except the signing took place directly in this package rather than via `eth-sig-util`. We don't use this method anywhere either.