### PR TITLE
Add standard `.gitignore` entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,11 @@
 
 # Dependency directories
 node_modules/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Output of 'npm pack'
+*.tgz


### PR DESCRIPTION
Debug logs and tarballs are now ignored.