### PR TITLE
Remove CircleCI badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Simple Keyring [![CircleCI](https://circleci.com/gh/MetaMask/eth-simple-keyring.svg?style=svg)](https://circleci.com/gh/MetaMask/eth-simple-keyring)
+# Simple Keyring
 
 A simple JS class wrapped around [ethereumjs-wallet](https://github.com/ethereumjs/ethereumjs-wallet) designed to expose an interface common to many different signing strategies to be used in a `KeyringController`; such as the one used in [MetaMask](https://metamask.io/)
 


### PR DESCRIPTION
We migrated from CircleCI to GitHub Actions in #68, but the badge from CircleCI was accidentally left behind.