### PR TITLE
Remove `ethereum-tx` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "eslint": "^7.2.0",
     "eslint-plugin-import": "^2.21.2",
     "eslint-plugin-json": "^2.1.1",
-    "ethereumjs-tx": "^2.1.0",
     "mocha": "^8.1.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -3,8 +3,7 @@
 const assert = require('assert')
 const ethUtil = require('ethereumjs-util')
 const sigUtil = require('eth-sig-util')
-const { Transaction: EthereumTx } = require('ethereumjs-tx')
-const { TransactionFactory } = require('@ethereumjs/tx')
+const { TransactionFactory, Transaction: EthereumTx } = require('@ethereumjs/tx')
 const { expect } = require('chai')
 const SimpleKeyring = require('..')
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -823,19 +823,6 @@ ethereumjs-abi@^0.6.8:
     bn.js "^4.11.8"
     ethereumjs-util "^6.0.0"
 
-ethereumjs-common@^1.3.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/ethereumjs-common/-/ethereumjs-common-1.3.1.tgz#a5cffac41beb7ad393283b2e5aa71fadf8a9cc73"
-  integrity sha512-kexqNgM2q29RKoZPPjehPREeqbr/vhYfT9Ho8FVeH3f7USjBuYp1iZ1qjqklk8FSMvEKPpMJFYSOunikw30Prw==
-
-ethereumjs-tx@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ethereumjs-tx/-/ethereumjs-tx-2.1.0.tgz#36b9e6a46383b18941644ba5264e1b506115c002"
-  integrity sha512-q1PFhR5i93OjcoE0G3GGz7XvnpLiddcUSKr28hmMUzVHvvc/+PHmQTx4NrGQUUny7qBq9tEIcvMivdB7uphKtA==
-  dependencies:
-    ethereumjs-common "^1.3.0"
-    ethereumjs-util "^6.0.0"
-
 ethereumjs-util@^5.1.1:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz#3e0c0d1741471acf1036052d048623dee54ad642"


### PR DESCRIPTION
This package was partially replaced by it's successor `@ethereumjs/tx` in #61, but was left around for the unit tests to ensure the keyring was compatible with both versions. Now that we have moved away from using `ethereum-tx` in in MetaMask itself, we don't really need to keep two versions of the same package around anymore.