### PR TITLE
Remove unused `events` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
   "dependencies": {
     "eth-sig-util": "^3.0.1",
     "ethereumjs-util": "^7.0.9",
-    "ethereumjs-wallet": "^1.0.1",
-    "events": "^1.1.1"
+    "ethereumjs-wallet": "^1.0.1"
   },
   "devDependencies": {
     "@ethereumjs/tx": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1237,11 +1237,6 @@ ethjs-util@^0.1.3:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
 
-events@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
-  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
-
 evp_bytestokey@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"


### PR DESCRIPTION
This dependency appears to be used, but in fact it is the Node.js `events` API that gets used, because it always takes precedent over package imports. This package was effectively ignored.

This package isn't required for browser compatibility anyway, as bundlers like Webpack and browserify will substitute Node.js APIs for browser-compatible implementations. That's how this has been working in practice.