### PR TITLE
Make the `wallets` property private

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,20 +9,20 @@ class SimpleKeyring extends EventEmitter {
   constructor(opts) {
     super();
     this.type = type;
-    this.wallets = [];
+    this._wallets = [];
     this.deserialize(opts);
   }
 
   serialize() {
     return Promise.resolve(
-      this.wallets.map((w) => w.getPrivateKey().toString('hex')),
+      this._wallets.map((w) => w.getPrivateKey().toString('hex')),
     );
   }
 
   deserialize(privateKeys = []) {
     return new Promise((resolve, reject) => {
       try {
-        this.wallets = privateKeys.map((privateKey) => {
+        this._wallets = privateKeys.map((privateKey) => {
           const stripped = ethUtil.stripHexPrefix(privateKey);
           const buffer = Buffer.from(stripped, 'hex');
           const wallet = Wallet.fromPrivateKey(buffer);
@@ -40,7 +40,7 @@ class SimpleKeyring extends EventEmitter {
     for (let i = 0; i < n; i++) {
       newWallets.push(Wallet.generate());
     }
-    this.wallets = this.wallets.concat(newWallets);
+    this._wallets = this._wallets.concat(newWallets);
     const hexWallets = newWallets.map((w) =>
       ethUtil.bufferToHex(w.getAddress()),
     );
@@ -49,7 +49,7 @@ class SimpleKeyring extends EventEmitter {
 
   getAccounts() {
     return Promise.resolve(
-      this.wallets.map((w) => ethUtil.bufferToHex(w.getAddress())),
+      this._wallets.map((w) => ethUtil.bufferToHex(w.getAddress())),
     );
   }
 
@@ -165,13 +165,13 @@ class SimpleKeyring extends EventEmitter {
 
   removeAccount(address) {
     if (
-      !this.wallets
+      !this._wallets
         .map((w) => ethUtil.bufferToHex(w.getAddress()).toLowerCase())
         .includes(address.toLowerCase())
     ) {
       throw new Error(`Address ${address} not found in this keyring`);
     }
-    this.wallets = this.wallets.filter(
+    this._wallets = this._wallets.filter(
       (w) =>
         ethUtil.bufferToHex(w.getAddress()).toLowerCase() !==
         address.toLowerCase(),
@@ -183,7 +183,7 @@ class SimpleKeyring extends EventEmitter {
    */
   _getWalletForAccount(account, opts = {}) {
     const address = sigUtil.normalize(account);
-    let wallet = this.wallets.find(
+    let wallet = this._wallets.find(
       (w) => ethUtil.bufferToHex(w.getAddress()) === address,
     );
     if (!wallet) {

--- a/test/index.js
+++ b/test/index.js
@@ -48,15 +48,9 @@ describe('simple-keyring', function () {
   describe('#deserialize a private key', function () {
     it('serializes what it deserializes', async function () {
       await keyring.deserialize([testAccount.key]);
-      assert.equal(keyring.wallets.length, 1, 'has one wallet');
       const serialized = await keyring.serialize();
+      assert.equal(serialized.length, 1, 'has one wallet');
       assert.equal(serialized[0], ethUtil.stripHexPrefix(testAccount.key));
-      const accounts = await keyring.getAccounts();
-      assert.deepEqual(
-        accounts,
-        [testAccount.address],
-        'accounts match expected',
-      );
     });
   });
 
@@ -166,30 +160,27 @@ describe('simple-keyring', function () {
     describe('with no arguments', function () {
       it('creates a single wallet', async function () {
         await keyring.addAccounts();
-        assert.equal(keyring.wallets.length, 1);
+        const serializedKeyring = await keyring.serialize();
+        assert.equal(serializedKeyring.length, 1);
       });
     });
 
     describe('with a numeric argument', function () {
       it('creates that number of wallets', async function () {
         await keyring.addAccounts(3);
-        assert.equal(keyring.wallets.length, 3);
+        const serializedKeyring = await keyring.serialize();
+        assert.equal(serializedKeyring.length, 3);
       });
     });
   });
 
   describe('#getAccounts', function () {
-    it('calls getAddress on each wallet', async function () {
+    it('should return a list of addresses in wallet', async function () {
       // Push a mock wallet
-      const desiredOutput = '0x18a3462427bcc9133bb46e88bcbe39cd7ef0e761';
-      keyring.wallets.push({
-        getAddress() {
-          return ethUtil.toBuffer(desiredOutput);
-        },
-      });
+      keyring.deserialize([testAccount.key]);
 
       const output = await keyring.getAccounts();
-      assert.equal(output[0], desiredOutput);
+      assert.equal(output[0], testAccount.address);
       assert.equal(output.length, 1);
     });
   });


### PR DESCRIPTION
The `wallets` property of the keyring has been renamed to `_wallets`, to communicate that it is meant to be private and is not part of the public API.

The tests have also been updated to avoid using any internal methods or properties.