### PR TITLE
Remove `ethereumjs-wallet`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,22 @@
 const { EventEmitter } = require('events');
-const Wallet = require('ethereumjs-wallet').default;
 const ethUtil = require('ethereumjs-util');
+const randomBytes = require('randombytes');
 
 const type = 'Simple Key Pair';
 const sigUtil = require('eth-sig-util');
+
+function generateKey() {
+  const privateKey = randomBytes(32);
+  // I don't think this is possible, but this validation was here previously,
+  // so it has been preserved just in case.
+  // istanbul ignore next
+  if (!ethUtil.isValidPrivate(privateKey)) {
+    throw new Error(
+      'Private key does not satisfy the curve requirements (ie. it is invalid)',
+    );
+  }
+  return privateKey;
+}
 
 class SimpleKeyring extends EventEmitter {
   constructor(opts) {
@@ -14,32 +27,36 @@ class SimpleKeyring extends EventEmitter {
   }
 
   async serialize() {
-    return this._wallets.map((w) => w.getPrivateKey().toString('hex'));
+    return this._wallets.map(({ privateKey }) => privateKey.toString('hex'));
   }
 
   async deserialize(privateKeys = []) {
-    this._wallets = privateKeys.map((privateKey) => {
-      const stripped = ethUtil.stripHexPrefix(privateKey);
-      const buffer = Buffer.from(stripped, 'hex');
-      const wallet = Wallet.fromPrivateKey(buffer);
-      return wallet;
+    this._wallets = privateKeys.map((hexPrivateKey) => {
+      const strippedHexPrivateKey = ethUtil.stripHexPrefix(hexPrivateKey);
+      const privateKey = Buffer.from(strippedHexPrivateKey, 'hex');
+      const publicKey = ethUtil.privateToPublic(privateKey);
+      return { privateKey, publicKey };
     });
   }
 
   async addAccounts(n = 1) {
     const newWallets = [];
     for (let i = 0; i < n; i++) {
-      newWallets.push(Wallet.generate());
+      const privateKey = generateKey();
+      const publicKey = ethUtil.privateToPublic(privateKey);
+      newWallets.push({ privateKey, publicKey });
     }
     this._wallets = this._wallets.concat(newWallets);
-    const hexWallets = newWallets.map((w) =>
-      ethUtil.bufferToHex(w.getAddress()),
+    const hexWallets = newWallets.map(({ publicKey }) =>
+      ethUtil.bufferToHex(ethUtil.publicToAddress(publicKey)),
     );
     return hexWallets;
   }
 
   async getAccounts() {
-    return this._wallets.map((w) => ethUtil.bufferToHex(w.getAddress()));
+    return this._wallets.map(({ publicKey }) =>
+      ethUtil.bufferToHex(ethUtil.publicToAddress(publicKey)),
+    );
   }
 
   // tx is an instance of the ethereumjs-transaction class.
@@ -70,7 +87,7 @@ class SimpleKeyring extends EventEmitter {
   // For eth_decryptMessage:
   async decryptMessage(withAccount, encryptedData) {
     const wallet = this._getWalletForAccount(withAccount);
-    const privKey = ethUtil.stripHexPrefix(wallet.getPrivateKey());
+    const privKey = ethUtil.stripHexPrefix(wallet.privateKey);
     const sig = sigUtil.decrypt(encryptedData, privKey);
     return sig;
   }
@@ -122,8 +139,7 @@ class SimpleKeyring extends EventEmitter {
       throw new Error('Must specify address.');
     }
     const wallet = this._getWalletForAccount(address, opts);
-    const privKey = ethUtil.toBuffer(wallet.getPrivateKey());
-    return privKey;
+    return wallet.privateKey;
   }
 
   // returns an address specific to an app
@@ -135,7 +151,7 @@ class SimpleKeyring extends EventEmitter {
       withAppKeyOrigin: origin,
     });
     const appKeyAddress = sigUtil.normalize(
-      wallet.getAddress().toString('hex'),
+      ethUtil.publicToAddress(wallet.publicKey).toString('hex'),
     );
     return appKeyAddress;
   }
@@ -143,21 +159,24 @@ class SimpleKeyring extends EventEmitter {
   // exportAccount should return a hex-encoded private key:
   async exportAccount(address, opts = {}) {
     const wallet = this._getWalletForAccount(address, opts);
-    return wallet.getPrivateKey().toString('hex');
+    return wallet.privateKey.toString('hex');
   }
 
   removeAccount(address) {
     if (
       !this._wallets
-        .map((w) => ethUtil.bufferToHex(w.getAddress()).toLowerCase())
+        .map(({ publicKey }) =>
+          ethUtil.bufferToHex(ethUtil.publicToAddress(publicKey)).toLowerCase(),
+        )
         .includes(address.toLowerCase())
     ) {
       throw new Error(`Address ${address} not found in this keyring`);
     }
     this._wallets = this._wallets.filter(
-      (w) =>
-        ethUtil.bufferToHex(w.getAddress()).toLowerCase() !==
-        address.toLowerCase(),
+      ({ publicKey }) =>
+        ethUtil
+          .bufferToHex(ethUtil.publicToAddress(publicKey))
+          .toLowerCase() !== address.toLowerCase(),
     );
   }
 
@@ -167,18 +186,20 @@ class SimpleKeyring extends EventEmitter {
   _getWalletForAccount(account, opts = {}) {
     const address = sigUtil.normalize(account);
     let wallet = this._wallets.find(
-      (w) => ethUtil.bufferToHex(w.getAddress()) === address,
+      ({ publicKey }) =>
+        ethUtil.bufferToHex(ethUtil.publicToAddress(publicKey)) === address,
     );
     if (!wallet) {
       throw new Error('Simple Keyring - Unable to find matching address.');
     }
 
     if (opts.withAppKeyOrigin) {
-      const privKey = wallet.getPrivateKey();
+      const { privateKey } = wallet;
       const appKeyOriginBuffer = Buffer.from(opts.withAppKeyOrigin, 'utf8');
-      const appKeyBuffer = Buffer.concat([privKey, appKeyOriginBuffer]);
-      const appKeyPrivKey = ethUtil.keccak(appKeyBuffer, 256);
-      wallet = Wallet.fromPrivateKey(appKeyPrivKey);
+      const appKeyBuffer = Buffer.concat([privateKey, appKeyOriginBuffer]);
+      const appKeyPrivateKey = ethUtil.keccak(appKeyBuffer, 256);
+      const appKeyPublicKey = ethUtil.privateToPublic(appKeyPrivateKey);
+      wallet = { privateKey: appKeyPrivateKey, publicKey: appKeyPublicKey };
     }
 
     return wallet;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "eth-sig-util": "^3.0.1",
     "ethereumjs-util": "^7.0.9",
-    "ethereumjs-wallet": "^1.0.1"
+    "randombytes": "^2.1.0"
   },
   "devDependencies": {
     "@ethereumjs/tx": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -895,11 +895,6 @@ acorn@^8.2.4:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.4.1.tgz#56c36251fc7cabc7096adc18f05afe814321a28c"
   integrity sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==
 
-aes-js@^3.1.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.1.2.tgz#db9aabde85d5caabbfc0d4f2a4446960f627146a"
-  integrity sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==
-
 agent-base@6:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
@@ -2021,18 +2016,6 @@ ethereumjs-util@^6.0.0:
     safe-buffer "^5.1.1"
     secp256k1 "^3.0.1"
 
-ethereumjs-util@^7.0.2:
-  version "7.0.10"
-  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.0.10.tgz#5fb7b69fa1fda0acc59634cf39d6b0291180fc1f"
-  integrity sha512-c/xThw6A+EAnej5Xk5kOzFzyoSnw0WX0tSlZ6pAsfGVvQj3TItaDg9b1+Fz1RJXA+y2YksKwQnuzgt1eY6LKzw==
-  dependencies:
-    "@types/bn.js" "^5.1.0"
-    bn.js "^5.1.2"
-    create-hash "^1.1.2"
-    ethereum-cryptography "^0.1.3"
-    ethjs-util "0.1.6"
-    rlp "^2.2.4"
-
 ethereumjs-util@^7.0.9:
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.0.9.tgz#2038baeb30f370a3e576ec175bd70bbbb6807d42"
@@ -2044,20 +2027,6 @@ ethereumjs-util@^7.0.9:
     ethereum-cryptography "^0.1.3"
     ethjs-util "0.1.6"
     rlp "^2.2.4"
-
-ethereumjs-wallet@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ethereumjs-wallet/-/ethereumjs-wallet-1.0.1.tgz#664a4bcacfc1291ca2703de066df1178938dba1c"
-  integrity sha512-3Z5g1hG1das0JWU6cQ9HWWTY2nt9nXCcwj7eXVNAHKbo00XAZO8+NHlwdgXDWrL0SXVQMvTWN8Q/82DRH/JhPw==
-  dependencies:
-    aes-js "^3.1.1"
-    bs58check "^2.1.2"
-    ethereum-cryptography "^0.1.3"
-    ethereumjs-util "^7.0.2"
-    randombytes "^2.0.6"
-    scrypt-js "^3.0.1"
-    utf8 "^3.0.0"
-    uuid "^3.3.2"
 
 ethjs-util@0.1.6:
   version "0.1.6"
@@ -4004,7 +3973,7 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-randombytes@^2.0.6, randombytes@^2.1.0:
+randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
@@ -4188,7 +4157,7 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-scrypt-js@^3.0.0, scrypt-js@^3.0.1:
+scrypt-js@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
   integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
@@ -4729,11 +4698,6 @@ uri-js@^4.2.2:
   integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
   dependencies:
     punycode "^2.1.0"
-
-utf8@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/utf8/-/utf8-3.0.0.tgz#f052eed1364d696e769ef058b183df88c87f69d1"
-  integrity sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
The `ethereumjs-wallet` package was replaced by a couple of simple utility functions. The only thing we used the "Wallet" abstraction for was generating a private key and getting the address that corresponds to that private key.

This should behave identically to how it did before, except now we have one less dependency. This is especially beneficial in this case because `ethereumjs-wallet` had transitive dependencies that were inconvenient for us (e.g. native dependencies and things that make LavaMoat unimpressed).

Closes #21, #59