### PR TITLE
Update Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+      time: '06:00'
     allow:
       - dependency-name: '@metamask/*'
-    versioning-strategy: 'increase'
+    target-branch: 'main'
+    versioning-strategy: 'increase-if-necessary'
+    open-pull-requests-limit: 10


### PR DESCRIPTION
The Dependabot config now matches the config in the MetaMask module template repository. The differences are minimal.