### PR TITLE
Remove redundant EventEmitter super class.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const { EventEmitter } = require('events');
 const ethUtil = require('ethereumjs-util');
 const randomBytes = require('randombytes');
 
@@ -26,9 +25,8 @@ function generateKey() {
   return privateKey;
 }
 
-class SimpleKeyring extends EventEmitter {
+class SimpleKeyring {
   constructor(opts) {
-    super();
     this.type = type;
     this._wallets = [];
     this.deserialize(opts);


### PR DESCRIPTION
The implementation does not call `emit` so it seems redundant.