### PR TITLE
bump @metamask/eth-sig-util to v5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@ethereumjs/util": "^8.0.0",
-    "@metamask/eth-sig-util": "^5.0.0",
+    "@metamask/eth-sig-util": "^5.0.1",
     "ethereum-cryptography": "^1.1.2",
     "randombytes": "^2.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -608,10 +608,10 @@
   resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-8.0.0.tgz#f4e3bcd6b37ec135b5a72902b0526cba2a6b5a4d"
   integrity sha512-ZO9B3ohNhjomrufNAkxnDXV46Kut7NKzri7itDxUzHJncNtI1of7ewWh6fKPl/hr6Al6Gd7WgjPdJZGFpzKPQw==
 
-"@metamask/eth-sig-util@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@metamask/eth-sig-util/-/eth-sig-util-5.0.0.tgz#106364008029d30a231668a7133d6d0dae60adf6"
-  integrity sha512-wBOfkmPJoQG3c6kfxxJxQKfzxqSVtMxRjMD4C6xNtGU+TEuBacC3jIgjUUPlC5MTWu4XFo1Y8VWrmc1AlwAitA==
+"@metamask/eth-sig-util@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@metamask/eth-sig-util/-/eth-sig-util-5.0.1.tgz#1200e9dc30e75431d8d3394a5f057a5b2a4c4fdc"
+  integrity sha512-+LzrvgqCGq/R/bOtBTGTRjm22u0L4j35cHl3m4N71+0l0M+sqnPkYJ51QEIhHeWQE2xgNojzci93/8Vj9TsYuQ==
   dependencies:
     "@ethereumjs/util" "^8.0.0"
     bn.js "4.11.8"


### PR DESCRIPTION
https://github.com/MetaMask/eth-simple-keyring/pull/109 bumped the version of `@metamask/eth-sig-util` to the now deprecated `5.0.0`. This bumps us to v`5.0.1` which fixes the issue introduced in `5.0.0`