### PR TITLE
modify publish-release.yml for non-build repo

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,16 +1,26 @@
 name: Publish Release
 
 on:
-  workflow_call:
-    secrets:
-      NPM_TOKEN:
-        required: true
+  push:
+    branches: [main]
 
 jobs:
+  is-release:
+    # release merge commits come from github-actions
+    if: startsWith(github.event.commits[0].author.name, 'github-actions')
+    outputs:
+      IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: MetaMask/action-is-release@v1
+        id: is-release
+
   publish-release:
     permissions:
       contents: write
+    if: needs.is-release.outputs.IS_RELEASE == 'true'
     runs-on: ubuntu-latest
+    needs: is-release
     steps:
       - uses: actions/checkout@v3
         with:
@@ -22,17 +32,6 @@ jobs:
       - uses: MetaMask/action-publish-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install
-        run: |
-          yarn install
-          yarn build
-      - uses: actions/cache@v3
-        id: restore-build
-        with:
-          path: |
-            ./dist
-            ./node_modules/.yarn-state.yml
-          key: ${{ github.sha }}
 
   publish-npm-dry-run:
     runs-on: ubuntu-latest
@@ -41,16 +40,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.sha }}
-      - uses: actions/cache@v3
-        id: restore-build
-        with:
-          path: |
-            ./dist
-            ./node_modules/.yarn-state.yml
-          key: ${{ github.sha }}
       - name: Dry Run Publish
         # omit npm-token token to perform dry run publish
-        uses: MetaMask/action-npm-publish@v2
+        uses: MetaMask/action-npm-publish@v1
         env:
           SKIP_PREPACK: true
 
@@ -62,15 +54,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.sha }}
-      - uses: actions/cache@v3
-        id: restore-build
-        with:
-          path: |
-            ./dist
-            ./node_modules/.yarn-state.yml
-          key: ${{ github.sha }}
       - name: Publish
-        uses: MetaMask/action-npm-publish@v2
+        uses: MetaMask/action-npm-publish@v1
         with:
           # This `NPM_TOKEN` needs to be manually set per-repository.
           # Look in the repository settings under "Environments", and set this token in the `npm-publish` environment.

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,9 +10,7 @@ jobs:
   publish-release:
     permissions:
       contents: write
-    if: needs.is-release.outputs.IS_RELEASE == 'true'
     runs-on: ubuntu-latest
-    needs: is-release
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,16 +7,6 @@ on:
         required: true
 
 jobs:
-  is-release:
-    # release merge commits come from github-actions
-    if: startsWith(github.event.commits[0].author.name, 'github-actions')
-    outputs:
-      IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: MetaMask/action-is-release@v1
-        id: is-release
-
   publish-release:
     permissions:
       contents: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,8 +1,10 @@
 name: Publish Release
 
 on:
-  push:
-    branches: [main]
+  workflow_call:
+    secrets:
+      NPM_TOKEN:
+        required: true
 
 jobs:
   is-release:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -42,7 +42,7 @@ jobs:
           ref: ${{ github.sha }}
       - name: Dry Run Publish
         # omit npm-token token to perform dry run publish
-        uses: MetaMask/action-npm-publish@v1
+        uses: MetaMask/action-npm-publish@v2
         env:
           SKIP_PREPACK: true
 
@@ -55,7 +55,7 @@ jobs:
         with:
           ref: ${{ github.sha }}
       - name: Publish
-        uses: MetaMask/action-npm-publish@v1
+        uses: MetaMask/action-npm-publish@v2
         with:
           # This `NPM_TOKEN` needs to be manually set per-repository.
           # Look in the repository settings under "Environments", and set this token in the `npm-publish` environment.


### PR DESCRIPTION
Per @Gudahtt 's comment [here](https://github.com/MetaMask/eth-simple-keyring/pull/123#discussion_r1029691682), the `publish-release` flow for this repo should not include build steps.