### PR TITLE
Delete `.yarnrc` file

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,0 @@
-ignore-scripts true


### PR DESCRIPTION
This file has not been used as of the Yarn v3 migration in https://github.com/MetaMask/eth-simple-keyring/pull/119. It was accidentally left behind.