### PR TITLE
Add `validateMessage` option to `signMessage`

### DIFF
--- a/src/simple-keyring.test.ts
+++ b/src/simple-keyring.test.ts
@@ -192,7 +192,7 @@ describe('simple-keyring', function () {
     it('throw error for invalid message', async function () {
       await keyring.deserialize([privateKey]);
       await expect(keyring.signMessage(address, '')).rejects.toThrow(
-        'Cannot convert 0x to a BigInt',
+        'Cannot sign invalid message',
       );
     });
 

--- a/src/simple-keyring.ts
+++ b/src/simple-keyring.ts
@@ -94,9 +94,15 @@ export default class SimpleKeyring implements Keyring<string[]> {
   async signMessage(
     address: Hex,
     data: string,
-    opts = { withAppKeyOrigin: '' },
+    opts = { withAppKeyOrigin: '', validateMessage: true },
   ) {
     const message = stripHexPrefix(data);
+    if (
+      opts.validateMessage &&
+      (message.length === 0 || !message.match(/^[a-fA-F0-9]*$/u))
+    ) {
+      throw new Error('Cannot sign invalid message');
+    }
     const privKey = this.#getPrivateKeyFor(address, opts);
     const msgSig = ecsign(Buffer.from(message, 'hex'), privKey);
     const rawMsgSig = concatSig(toBuffer(msgSig.v), msgSig.r, msgSig.s);


### PR DESCRIPTION
`signMessage` is supposed to be rejecting malformed input but relies on implicit behavior in dependencies to do so. This makes it brittle and it can be seen failing here: https://github.com/MetaMask/eth-simple-keyring/actions/runs/6053985322/job/16430596839

This adds validation that the string has a length and is a hexadecimal string with optional `0x`-prefix. It makes it optional via the new `validateMessage` option (default: `true`)