### PR TITLE
Revert "5.1.0 (#151)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [5.1.0]
-### Changed
-- Export TypeScript interfaces ([#140](https://github.com/MetaMask/eth-simple-keyring/pull/140))
-- Update all dependencies ([#140](https://github.com/MetaMask/eth-simple-keyring/pull/140)) ([#149](https://github.com/MetaMask/eth-simple-keyring/pull/149))
-
-### Fixed
-- Add `validateMessage` option to `signMessage` to configure if runtime-validation should be done that input string is hex (default: `true`) ([#148](https://github.com/MetaMask/eth-simple-keyring/pull/148))
-
 ## [5.0.0]
 ### Changed
 - **BREAKING:** Makes version-specific `signTypedData` methods private ([#84](https://github.com/MetaMask/eth-simple-keyring/pull/84))
@@ -29,6 +21,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** Remove redundant `newGethSignMessage` method ([#72](https://github.com/MetaMask/eth-simple-keyring/pull/72))
     - Consumers can use `signPersonalMessage` method as a replacement for `newGethSignMessage`.
 
-[Unreleased]: https://github.com/MetaMask/eth-simple-keyring/compare/v5.1.0...HEAD
-[5.1.0]: https://github.com/MetaMask/eth-simple-keyring/compare/v5.0.0...v5.1.0
+[Unreleased]: https://github.com/MetaMask/eth-simple-keyring/compare/v5.0.0...HEAD
 [5.0.0]: https://github.com/MetaMask/eth-simple-keyring/releases/tag/v5.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eth-simple-keyring",
-  "version": "5.1.0",
+  "version": "5.0.0",
   "description": "A simple standard interface for a series of Ethereum private keys.",
   "keywords": [
     "ethereum",


### PR DESCRIPTION
This reverts commit d0d5c9750286b624a01dc48fe25d52858a5810f4 which released v5.1.0. This is only done in order to get a proper publish from the main branch after merge of #157, which fixes a CI error.

5.1.0 should be re-released and published as-is immediately following this.
