### PR TITLE
fix: treat undefined/null as [] in deserialize

### DIFF
--- a/src/simple-keyring.test.ts
+++ b/src/simple-keyring.test.ts
@@ -73,6 +73,17 @@ describe('simple-keyring', function () {
     });
   });
 
+  describe('#deserialize an empty value', function () {
+    it('resets wallets', async function () {
+      await keyring.deserialize([testAccount.key]);
+      const serialized = await keyring.serialize();
+      expect(serialized).toHaveLength(1);
+      await keyring.deserialize(undefined);
+      const serialized2 = await keyring.serialize();
+      expect(serialized2).toHaveLength(0);
+    });
+  });
+
   describe('#constructor with a private key', function () {
     it('has the correct addresses', async function () {
       const newKeyring = new SimpleKeyring([testAccount.key]);

--- a/src/simple-keyring.ts
+++ b/src/simple-keyring.ts
@@ -50,7 +50,7 @@ export default class SimpleKeyring implements Keyring<string[]> {
     return this.#wallets.map((a) => a.privateKey.toString('hex'));
   }
 
-  async deserialize(privateKeys: string[]) {
+  async deserialize(privateKeys: string[] = []) {
     this.#wallets = privateKeys.map((hexPrivateKey) => {
       const strippedHexPrivateKey = stripHexPrefix(hexPrivateKey);
       const privateKey = Buffer.from(strippedHexPrivateKey, 'hex');


### PR DESCRIPTION
Passing `undefined` as argument to `deserialize` currently throws an error. This adds a default argument to match constructor behavior (treat it the same as `[]`).